### PR TITLE
V2 engine quotes

### DIFF
--- a/dune-engine-v2-beta/query-engine.md
+++ b/dune-engine-v2-beta/query-engine.md
@@ -28,7 +28,6 @@ The changes between the 2 coding languages syntax and the keyword operators are 
 | **encoding strings to hex**                                              | `encode(string, 'hex')`                                                                                                                                                   | `hex(string)`                                                                                                               |
 | <p><strong>Get json object</strong><br><strong>differences</strong></p>  | <p><code>("takerOutputUpdate"-></code><br><code>'deltaWei'->'value'</code>)<br><br><br><code>decode(substring(("addressSet"->'baseAsset')::TEXT, 4,40), 'hex')</code></p> | <p><code>get_json_object(get_json_object(takerOutputUpdate,'$.deltaWei'),'$.value')</code><br><br><code>'0x'</code></p>     |
 
-If you have found any other changes that are important to note, please feel free to sumbit a PR to our docs or leave us feedback in Discord!
 
 If you have found any other changes that are important to note, please feel free to sumbit a PR to our docs or leave us feedback in [Discord](https://discord.com/dunecom)!
 

--- a/dune-engine-v2-beta/query-engine.md
+++ b/dune-engine-v2-beta/query-engine.md
@@ -28,6 +28,7 @@ The changes between the 2 coding languages syntax and the keyword operators are 
 | **encoding strings to hex**                                              | `encode(string, 'hex')`                                                                                                                                                   | `hex(string)`                                                                                                               |
 | <p><strong>Get json object</strong><br><strong>differences</strong></p>  | <p><code>("takerOutputUpdate"-></code><br><code>'deltaWei'->'value'</code>)<br><br><br><code>decode(substring(("addressSet"->'baseAsset')::TEXT, 4,40), 'hex')</code></p> | <p><code>get_json_object(get_json_object(takerOutputUpdate,'$.deltaWei'),'$.value')</code><br><br><code>'0x'</code></p>     |
 
+It is recommended to not use double quotes in DuneV2 at all, even when the engine can run the query and does not return an error. Characters enclosed in double quotes can be treated differently depending on the structure of a query which can lead to confusing and inconsistent behavior.
 
 If you have found any other changes that are important to note, please feel free to sumbit a PR to our docs or leave us feedback in [Discord](https://discord.com/dunecom)!
 


### PR DESCRIPTION
Add line about recommending not using double quotes in DuneV2.

Also removes a duplicate/typo line from a previous commit.

Reason to not use double quotes is sometimes the parser treats words in double quotes as a string and sometimes it treats them as an object (column name for example). This can cause some confusing behavior. 

For example, referencing a column name in the where clause using double quotes works as expected. However, the same query inside a CTE treats the column name as a string.

https://dune.com/queries/1199604