### PR TITLE
Update links for changes from commit #1424

### DIFF
--- a/data-tables/prices.md
+++ b/data-tables/prices.md
@@ -13,7 +13,7 @@ The Price is the volume-weighted price based on real-time market data, translate
 ### **prices.usd**
 
 This table supports a range of erc20.tokens. \
-If the token you desire is not listed in here, please make a pull request to our [github repository](https://github.com/duneanalytics/abstractions/tree/master/prices) **** or use the decentralized price feed **dex.view\_token\_prices.**
+If the token you desire is not listed in here, please make a pull request to our [github repository for V2](https://github.com/duneanalytics/spellbook/blob/main/models/prices/prices_tokens.sql), [github repository for V1]([https://github.com/duneanalytics/abstractions/tree/master/prices](https://github.com/duneanalytics/spellbook/tree/main/deprecated-dune-v1-abstractions/prices)), or use the decentralized price feed **dex.view\_token\_prices.**
 
 | <p></p><p><strong>column name</strong></p> | **description**                               |
 | ------------------------------------------ | --------------------------------------------- |


### PR DESCRIPTION
Commit #1424 broke the links on the [Prices - Dune Docs](https://docs.dune.com/data-tables/prices) page.  Correcting the V1 link and adding in the V2 link.