### PR TITLE
Fix broken link on "Dune Pro" feature page

### DIFF
--- a/docs/features/pro.md
+++ b/docs/features/pro.md
@@ -10,7 +10,7 @@ Dune pro let's you access a host of premium features including:
 - No Dune watermarks
 - Processing for up to 6 Queries at once
 
-[Learn more and get started on our Pricing page](dune.com/pricing)!
+[Learn more and get started on our Pricing page](https://dune.com/pricing)!
 
 
 


### PR DESCRIPTION
Previously, this would link to `https://dune.com/docs/features/pro/dune.com/pricing`