### PR TITLE
upgraded to Node 18

### DIFF
--- a/docs/api/quick-start/api-js.md
+++ b/docs/api/quick-start/api-js.md
@@ -13,12 +13,12 @@ We'll show you one of the several ways the API can be consumed via JavaScript, i
 !!! example "Prerequisites"
     This Quick Start Guide assumes you have some level of familiarity with Node.js (Node), Node Package Manager (NPM) and Node Version Manager (NVM).
 
-To start, make sure you're using the current LTS version of Node.js (Node 16) and the latest version of NPM:
+To start, make sure you're using the current LTS version of Node.js (Node 18) and the latest version of NPM:
 
 ## Getting Set Up
 
 ```
-nvm use lts
+nvm use --lts
 npm install latest
 ```
 

--- a/docs/api/quick-start/community-clients.md
+++ b/docs/api/quick-start/community-clients.md
@@ -8,7 +8,7 @@ Our community once again comes through for the win with the below API clients.
 If you've built your own let us know about it in our [#dune-api Discord Channel](https://discord.com/channels/757637422384283659/1019910980634939433)!
 
 !!! warning "Disclaimer"
-    While we love that our community has taken the lead, these clients are not directly maintained by the Dune team. This means we can't guarantee they're bug free and might not be able to help if they aren't.
+    While we love that our community has taken the lead, these clients are not directly maintained by the Dune team.
 
 ## Cow Protocol Python Client
 


### PR DESCRIPTION
Node's latest LTS verson is now 18. I tested the code in the JS with this, and it works.

Also removed the extra precautionary line on community clients page. We can trust Ben and team to maintain the clients well.