### PR TITLE
Update Gnosis Chain section

### DIFF
--- a/docs/tables/available-chains.md
+++ b/docs/tables/available-chains.md
@@ -19,15 +19,9 @@ Explaining the Ethereum history, Roadmap and technical details goes beyond the s
 
 ## Gnosis Chain (xDai)
 
-Gnosis Chain is the predecessor of xDAI. It's a unique system in which the native fee currency is a bridged version of the stablecoin $DAI. The chain uses a unique dual-token model; $xDai is a stable token used for transactions, payments, and fees; Proof of Stake protection will be provided by $GNO with the consensus-layer Gnosis Beacon Chain.
+Gnosis Chain is the successor to xDAI. It's a unique system in which the native fee currency is a bridged version of the stablecoin $DAI which allows for inexpensive transactions. The chain uses a unique dual-token model; $xDai is a stable token used for transactions, payments, and fees; Proof of Stake protection is provided by $GNO with the consensus-layer Gnosis Beacon Chain.
 
-Gnosis Chain is yet to complete it's transition to an open proof of stake system, in the meanwhile the chain is being maintained by the POSDAO. You can read more about this transitional state [here](https://developers.gnosischain.com/for-validators/consensus).
-
-Gnosis Chain will continue xDai’s intent to follow the Ethereum roadmap as closely as possible. Future goals include:
-
-* Offer the highest degree of compatibility between Gnosis Chain and Ethereum
-* Set up a Gnosis Beacon Chain (in preparation of a later merge)
-* Develop over time a role similar to what Kusama is to Polkadot
+You can read more about Gnosis Chain and their specifications in their [documentation](https://docs.gnosischain.com/).
 
 Gnosis Chain follows all standards and upgrades of Ethereum Mainnet, querying on Dune is exactly the same.
 


### PR DESCRIPTION
* Updated to reflect that Gnosis Chain is now POS.
  * It successfully merged in December.
* Swaped 'predecessor' with 'successor' since Gnosis Chain came later.
* Removed the roadmap info because it was very out of date. 
  * I've requested the updated roadmap and will update it when I have it.
* Added link to official Gnosis Chain documentation.