### PR TITLE
Remove Unnecessary Characters (slash & single quote)

### DIFF
--- a/docs/api/api-reference/execution-results.md
+++ b/docs/api/api-reference/execution-results.md
@@ -31,7 +31,7 @@ curl -X GET "https://api.dune.com/api/v1/execution/{{execution_id}}/results" -H 
 There is a default 250,000 datapoints limit to make sure you don't accidently spend all your credits in one call. You can see it with the API param below:
 
 ```
-curl -X GET "https://api.dune.com/api/v1/execution/{{execution_id}}/results/?ignore_max_datapoints_per_request/=true" -H x-dune-api-key:{{api_key}}'
+curl -X GET "https://api.dune.com/api/v1/execution/{{execution_id}}/results/?ignore_max_datapoints_per_request=true" -H x-dune-api-key:{{api_key}}
 ```
 
 ## Example Response

--- a/docs/api/api-reference/latest_results.md
+++ b/docs/api/api-reference/latest_results.md
@@ -35,7 +35,7 @@ curl -X GET "https://api.dune.com/api/v1/query/{{query_id}}/results" -H x-dune-a
 There is a default 250,000 datapoints limit to make sure you don't accidently spend all your credits in one call. You can see it with the API param below:
 
 ```
-curl -X GET "https://api.dune.com/api/v1/query/{{query_id}}/results\?ignore_max_datapoints_per_request\=true" -H x-dune-api-key:{{api_key}}'
+curl -X GET "https://api.dune.com/api/v1/query/{{query_id}}/results\?ignore_max_datapoints_per_request=true" -H x-dune-api-key:{{api_key}}
 ```
 
 ### Python


### PR DESCRIPTION
I noticed that there were two awkward characters in the docs. The slash actually doesn't appear to make a difference since the endpoint seems to return this unexpected response always:

```
<a href="/api/v1/execution/01H22T5ZYMWVCAWJP8DTX3NXE2/results?ignore_max_datapoints_per_request=true">Moved Permanently</a>.
```

but the single quote on the end caused the request to fail.