### PR TITLE
T-31850: Second attempt fixing broken links

### DIFF
--- a/docs/app/decoding-contracts.md
+++ b/docs/app/decoding-contracts.md
@@ -7,7 +7,7 @@ description: Here's everything you need to know about Decoded contracts and how 
 
 Instead of working with raw transaction, log, and trace data, contracts are decoded into human-readable tables for each event and function defined in the smart contract's ABI ([Application Binary Interface](https://www.alchemy.com/overviews/what-is-an-abi-of-a-smart-contract-examples-and-usage)).
 
-Learn more about how Decoding works and what Decoded tables are available in the [data tables section](../data-tables/decoded/).
+Learn more about how Decoding works and what Decoded tables are available in the [data tables section](../../data-tables/decoded/).
 
 ## Submitting a new contract for decoding
 

--- a/docs/app/upload-data.md
+++ b/docs/app/upload-data.md
@@ -31,7 +31,7 @@ Anything that represents a timestamp is especially tricky for automated systems 
 ## How to Upload Data
 
 !!! note
-    You can also upload data via the API. Check out the [API documentation](../api/api-reference/upload-data/) for more information.
+    You can also upload data via the API. Check out the [API documentation](../../api/api-reference/upload-data/) for more information.
 
 
 


### PR DESCRIPTION
Turns out these markdown files behaves like paths in the url, i.e.
app/decoding-contracts/ and not app/decoding-contracts.md . So we need
to go back an extra level.

Sorry for not testing this before merging the previous one.