### PR TITLE
Update auth and get query docs

### DIFF
--- a/docs/api/api-reference/authentication.md
+++ b/docs/api/api-reference/authentication.md
@@ -3,14 +3,26 @@ title: Authentication
 description: Here's how to authenticate your API requests.
 ---
 
-The Dune API uses API keys to authenticate requests. Your API key is used to determine the permissions of private queries you may call, as well as which account to bill for the requests, so be sure to keep them secure! 
+The Dune API uses API keys to authenticate requests. Your API key is used to determine the permissions of private queries you may call, as well as which account to bill for the requests, so be sure to keep them secure!
 
 **Do not share your secret API keys in publicly accessible areas such as GitHub, client-side code, and so forth.**
 
-Authentication with the API is performed by adding an “x-dune-api-key” property to the request header. This is needed on all request types!
+## Header
+
+Authentication with the API can be performed by adding an “x-dune-api-key” property to the request header.
 
 Here's one example of doing this with an Execute POST API request:
 
 ```
 curl -X POST -H x-dune-api-key:{{api_key}} "https://api.dune.com/api/v1/query/{{query_id}}/execute"
+```
+
+## Query Parameter
+
+Authentication with the API can also be performed by adding an `api_key` query paramater.
+
+Here's one example of doing this with an Execute POST API request:
+
+```
+curl -X POST "https://api.dune.com/api/v1/query/{{query_id}}/execute?api_key={{api_key}}"
 ```

--- a/docs/api/api-reference/edit-queries/get-query.md
+++ b/docs/api/api-reference/edit-queries/get-query.md
@@ -6,7 +6,7 @@ description: Here's how to get or retrieve query info via Dune API
 !!! abstract "ENDPOINTS"
     GET /api/v1/query/{{query_id}}
 
-!!! success end "Note" 
+!!! success end "Note"
     This endpoint is included only in our Premium subscription plans.
 
 This endpoint will get details about a query (public, owned by the user, or a team the user belongs to), given the query ID. In the future we will likely also support getting a specific version, but for now, it returns data for the latest version.
@@ -17,7 +17,7 @@ User will be permissioned to get any public queries, private queries user owns, 
 
 ### cURL
 ```cURL
-curl -X GET "https://api.dune.com/api/v1/query/{{query_id}}/execute"   \
+curl -X GET "https://api.dune.com/api/v1/query/{{query_id}}"   \
   -H X-Dune-API-key: {{api_key}}
 ```
 


### PR DESCRIPTION
## Context
I noticed some missing / incorrect things when using the docs recently.

## What was done
- Add the api_key as query param doc
- Fix the example of the get query docs
