### PR TITLE
Remove an extra tick(`) symbol in string.md

### DIFF
--- a/docs/query/DuneSQL-reference/Functions-and-operators/string.md
+++ b/docs/query/DuneSQL-reference/Functions-and-operators/string.md
@@ -210,7 +210,7 @@ Here are some examples illustrating the translate function:
     SELECT translate('abcd', 'a', 'zy'); -- 'zbcd'
     SELECT translate('abcd', 'ac', 'z'); -- 'zbd'
     SELECT translate('abcd', 'aac', 'zq'); -- 'zbd'
-````
+```
 
 #### trim()
 **``trim(string)``** → varchar


### PR DESCRIPTION
There is an extra tick(`) symbol at the end of translate function section's code examples. It prevents the next section from being shown correctly.